### PR TITLE
The browser client page is not responding when run ftpserver in windows

### DIFF
--- a/ossftp/oss_fs_impl.py
+++ b/ossftp/oss_fs_impl.py
@@ -61,6 +61,8 @@ class OssFsImpl:
         return object
 
     def get_file_operation_instance(self, path):
+        if str(path).find(":") == 1:
+            path = path[2:]
         return oss_file_operation.OssFileOperation(self.get_bucket(path), self.get_object(path), self.size_cache, self.dir_cache)
 
     def open_read(self, path):


### PR DESCRIPTION
- 问题：当 ftpserver 在 windows 上运行时，oss 用户使用浏览器登录成功后，会出现网页无响应的情况。具体表现为：IE 浏览器能够成功登录却无法执行操作；Chrome 浏览器表现为，登录后网页无响应。
- 分析：经调查，用户成功登录 ftp 后，会对操作对象进行一系列属性请求，在请求 SIZE(文件大小) 时，第三方库 pyftpdlib 会将将我们的 path 自动加上盘符号，初步定为为 filesystems.py 中 realpath() 方法，导致本来的正常 path，如 “/bucketname/objectname”变成“D:/bucketname/objectname”。
- 解决方案：在请求对 bucket 或 object 的操作时，检查路径即可。